### PR TITLE
Updated vasp_input.py to fix POTCAR bug

### DIFF
--- a/doped/vasp_input.py
+++ b/doped/vasp_input.py
@@ -182,10 +182,10 @@ def vasp_gam_files(
     )  # Ignore POTCAR warnings because Pymatgen incorrectly detecting POTCAR types
     potcar_dict = deepcopy(default_potcar_dict)
     if potcar_settings: 
-        if 'POTCAR_FUNCTIONAL' in potcar_settings.keys(): 
-            potcar_dict['POTCAR_FUNCTIONAL'] = potcar_settings['POTCAR_FUNCTIONAL']
-        if 'POTCAR' in potcar_settings.keys():
-            potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR"))   
+         if "POTCAR_FUNCTIONAL" in potcar_settings.keys():
+             potcar_dict["POTCAR_FUNCTIONAL"] = potcar_settings["POTCAR_FUNCTIONAL"]
+         if "POTCAR" in potcar_settings.keys():
+             potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR")) 
 
     defect_relax_set = DefectRelaxSet(supercell, charge=single_defect_dict["Transformation "
                                                                            "Dict"]["charge"],
@@ -321,13 +321,14 @@ def vasp_std_files(
         "ignore", category=BadInputSetWarning
     )  # Ignore POTCAR warnings because Pymatgen incorrectly detecting POTCAR types
 
+    # POTCAR
     potcar_dict = deepcopy(default_potcar_dict)
-    if potcar_settings: 
-        if 'POTCAR_FUNCTIONAL' in potcar_settings.keys(): 
-            potcar_dict['POTCAR_FUNCTIONAL'] = potcar_settings['POTCAR_FUNCTIONAL']
-        if 'POTCAR' in potcar_settings.keys():
-            potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR"))   
-            
+    if potcar_settings:
+         if "POTCAR_FUNCTIONAL" in potcar_settings.keys():
+             potcar_dict["POTCAR_FUNCTIONAL"] = potcar_settings["POTCAR_FUNCTIONAL"]
+         if "POTCAR" in potcar_settings.keys():
+             potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR"))  
+         
     defect_relax_set = DefectRelaxSet(supercell, charge=single_defect_dict["Transformation "
                                                                            "Dict"]["charge"],
                                       user_potcar_settings=potcar_dict["POTCAR"],
@@ -460,11 +461,11 @@ def vasp_ncl_files(
     )  # Ignore POTCAR warnings because Pymatgen incorrectly detecting POTCAR types
 
     potcar_dict = deepcopy(default_potcar_dict)
-    if potcar_settings: 
-        if 'POTCAR_FUNCTIONAL' in potcar_settings.keys(): 
-            potcar_dict['POTCAR_FUNCTIONAL'] = potcar_settings['POTCAR_FUNCTIONAL']
-        if 'POTCAR' in potcar_settings.keys():
-            potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR"))   
+    if potcar_settings:
+         if "POTCAR_FUNCTIONAL" in potcar_settings.keys():
+             potcar_dict["POTCAR_FUNCTIONAL"] = potcar_settings["POTCAR_FUNCTIONAL"]
+         if "POTCAR" in potcar_settings.keys():
+             potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR")) 
     defect_relax_set = DefectRelaxSet(supercell, charge=single_defect_dict["Transformation "
                                                                            "Dict"]["charge"],
                                       user_potcar_settings=potcar_dict["POTCAR"],
@@ -651,10 +652,14 @@ def vasp_converge_files(
     warnings.filterwarnings(
         "ignore", category=BadInputSetWarning
     )  # Ignore POTCAR warnings because Pymatgen incorrectly detecting POTCAR types
-    potcar_dict = default_potcar_dict
+    
+    # POTCAR
+    potcar_dict = deepcopy(default_potcar_dict)
     if potcar_settings:
-        potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR"))
-        potcar_dict.update(potcar_settings)
+         if "POTCAR_FUNCTIONAL" in potcar_settings.keys():
+             potcar_dict["POTCAR_FUNCTIONAL"] = potcar_settings["POTCAR_FUNCTIONAL"]
+         if "POTCAR" in potcar_settings.keys():
+             potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR") 
     vaspconvergeinput = DictSet(structure, config_dict=potcar_dict)
     vaspconvergeinput.potcar.write_file(vaspconvergeinputdir + "POTCAR")
 
@@ -757,8 +762,10 @@ def vasp_std_chempot(
     # POTCAR
     potcar_dict = default_potcar_dict
     if potcar_settings:
-        potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR"))
-        potcar_dict.update(potcar_settings)
+         if "POTCAR_FUNCTIONAL" in potcar_settings.keys():
+             potcar_dict["POTCAR_FUNCTIONAL"] = potcar_settings["POTCAR_FUNCTIONAL"]
+         if "POTCAR" in potcar_settings.keys():
+             potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR")) 
     vaspstdinput = DictSet(structure, config_dict=potcar_dict)
     vaspstdinput.potcar.write_file(vaspstdinputdir + "POTCAR")
 
@@ -876,8 +883,10 @@ def vasp_ncl_chempot(
     # POTCAR
     potcar_dict = default_potcar_dict
     if potcar_settings:
-        potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR"))
-        potcar_dict.update(potcar_settings)
+         if "POTCAR_FUNCTIONAL" in potcar_settings.keys():
+             potcar_dict["POTCAR_FUNCTIONAL"] = potcar_settings["POTCAR_FUNCTIONAL"]
+         if "POTCAR" in potcar_settings.keys():
+             potcar_dict["POTCAR"].update(potcar_settings.pop("POTCAR"))
     vaspnclinput = DictSet(structure, config_dict=potcar_dict)
     vaspnclinput.potcar.write_file(vaspnclinputdir + "POTCAR")
 


### PR DESCRIPTION
Updated the commands that generate the POTCARs to accept a potcar functional without also requiring a specific potcar.

[3_Chemical_Potentials_Inputs-POTCARS.pdf](https://github.com/SMTG-UCL/doped/files/9462773/3_Chemical_Potentials_Inputs-POTCARS.pdf)
