### PR TITLE
Fix for parsing interstitial and substitution defects

### DIFF
--- a/doped/pycdt/utils/parse_calculations.py
+++ b/doped/pycdt/utils/parse_calculations.py
@@ -224,7 +224,8 @@ def get_defect_site_idxs_and_unrelaxed_structure(
 
         defect_coords = defect_new_species_coords[defect_site_idx]
 
-        defect_site_idx = defect_new_species_idx[defect_site_idx] # Get true site index
+        # Get the site index of the defect that was used in the VASP calculation
+        defect_site_idx = defect_new_species_idx[defect_site_idx]
 
         # now find the closest old_species site in the bulk structure to the defect site
         # again, make sure to use periodic boundaries
@@ -302,6 +303,7 @@ def get_defect_site_idxs_and_unrelaxed_structure(
 
     elif defect_type == "interstitial":
         new_species = list(composition_diff.keys())[0]
+
         bulk_new_species_coords = np.array(
             [site.frac_coords for site in bulk if site.specie.name == new_species]
         )
@@ -331,10 +333,13 @@ def get_defect_site_idxs_and_unrelaxed_structure(
             )[0]
 
         else:  # extrinsic interstitial
-            defect_site_idx = 0 
+            defect_site_idx = 0
 
         defect_site_coords = defect_new_species_coords[defect_site_idx]
-        defect_site_idx = defect_new_species_idx[defect_site_idx] # Get true site index
+
+        # Get the site index of the defect that was used in the VASP calculation
+        defect_site_idx = defect_new_species_idx[defect_site_idx]
+
         # create unrelaxed defect structure
         unrelaxed_defect_structure = bulk.copy()
         #Place defect in same location as output from DFT

--- a/tests/test_parse_calculations.py
+++ b/tests/test_parse_calculations.py
@@ -138,10 +138,10 @@ class DopedParsingTestCase(unittest.TestCase):
                 sdp.run_compatibility()
                 te_cd_1_ent = sdp.defect_entry
 
-        self.assertAlmostEqual(te_cd_1_ent.energy, -2.7494, places=3)
+        self.assertAlmostEqual(te_cd_1_ent.energy, -2.665996, places=3)
         self.assertAlmostEqual(te_cd_1_ent.uncorrected_energy, -2.906, places=3)
         correction_dict = {
-            "charge_correction": 0.15660728758716663,
+            "charge_correction": 0.24005014473002428,
             "bandfilling_correction": -0.0,
             "bandedgeshifting_correction": 0.0,
         }


### PR DESCRIPTION
This is a fix for ```get_defect_site_idxs_and_unrelaxed_structure()``` to allow the parsing of defects when the defect isn’t the last row in the ```POSCAR``` file. Now the structure returned by ```get_defect_site_idxs_and_unrelaxed_structure()``` has the defect site in the same position as it was during the DFT VASP calculation. Necessary for parsing site potentials from the ```OUTCAR```. This results in the correct kumugai correction now being applied correctly. Have had to modify the test for ```as_1_Te_on_Cd_1```.
### Example
Original implementation for a Te on a Cd site in CdTe:

<img width="447" alt="image" src="https://user-images.githubusercontent.com/56972784/208909987-d1315142-5e5d-47fa-a85b-6a85e2b5eda9.png">

New implementation for a Te on a Cd site in CdTe:

<img width="633" alt="image" src="https://user-images.githubusercontent.com/56972784/208910013-a02481d1-3706-4ea8-a34b-4b8bfeae3b75.png">

