### PR TITLE
Make "initial_defect_structure" take precedence for kumagai

### DIFF
--- a/doped/pycdt/utils/parse_calculations.py
+++ b/doped/pycdt/utils/parse_calculations.py
@@ -1375,7 +1375,7 @@ def get_site_mapping_indices(structure_a: Structure, structure_b: Structure, thr
         if current_dist > threshold:
             sitea = structure_a[index]
             siteb = structure_b[template_index]
-            warnings.warn(f"Large site displacement {current_dist} detected when matching atomic sites: {sitea}->{siteb}.")
+            warnings.warn(f"Large site displacement {current_dist:.4f} detected when matching atomic sites: {sitea}-> {siteb}.")
     return min_dist_with_index
 
 

--- a/doped/pycdt/utils/parse_calculations.py
+++ b/doped/pycdt/utils/parse_calculations.py
@@ -717,13 +717,13 @@ class SingleDefectParser:
 
         bulk_structure = self.defect_entry.bulk_structure
         bulksites = [site.frac_coords for site in bulk_structure]
-        if "unrelaxed_defect_structure" in self.defect_entry.parameters:
+        if "initial_defect_structure" in self.defect_entry.parameters:
+            defect_structure = self.defect_entry.parameters["initial_defect_structure"]
+            initsites = [site.frac_coords for site in defect_structure]
+        elif "unrelaxed_defect_structure" in self.defect_entry.parameters:
             defect_structure = self.defect_entry.parameters[
                 "unrelaxed_defect_structure"
             ]
-            initsites = [site.frac_coords for site in defect_structure]
-        elif "initial_defect_structure" in self.defect_entry.parameters:
-            defect_structure = self.defect_entry.parameters["initial_defect_structure"]
             initsites = [site.frac_coords for site in defect_structure]
         else:
             defect_structure = self.defect_entry.defect.generate_defect_structure()

--- a/doped/pycdt/utils/parse_calculations.py
+++ b/doped/pycdt/utils/parse_calculations.py
@@ -1346,7 +1346,7 @@ class PostProcess:
         return output
 
 
-def get_site_mapping_indices(structure_a: Structure, structure_b: Structure, threshold=0.5):
+def get_site_mapping_indices(structure_a: Structure, structure_b: Structure, threshold=1.0):
     """
     Reset the position of a partially relaxed structure to its unrelaxed positions.
     The template structure may have a different species ordering to the `input_structure`.
@@ -1363,20 +1363,23 @@ def get_site_mapping_indices(structure_a: Structure, structure_b: Structure, thr
     for index in range(len(input_fcoords)):
         dists = dmat[index]
         template_index = dists.argmin()
+        current_dist = dists.min()
         min_dist_with_index.append(
             [
-            dists.min(),
+            current_dist,
             index,
             template_index,
             ]
         )
-    max_disp = max(tmp[0] for tmp in min_dist_with_index)
-    if max_disp > threshold:
-        raise RuntimeError("Maximum displacement")
+
+        if current_dist > threshold:
+            sitea = structure_a[index]
+            siteb = structure_b[template_index]
+            warnings.warn(f"Large site displacement {current_dist} detected when matching atomic sites: {sitea}->{siteb}.")
     return min_dist_with_index
 
 
-def reorder_unrelaxed_structure(unrelaxed_structure: Structure, initial_relax_structure: Structure, threshold=0.5):
+def reorder_unrelaxed_structure(unrelaxed_structure: Structure, initial_relax_structure: Structure, threshold=1.0):
     """
     Reset the position of a partially relaxed structure to its unrelaxed positions.
     The template structure may have a different species ordering to the `input_structure`.

--- a/doped/pycdt/utils/parse_calculations.py
+++ b/doped/pycdt/utils/parse_calculations.py
@@ -419,6 +419,7 @@ class SingleDefectParser:
         :param dielectric (float or 3x3 matrix): ionic + static contributions to dielectric constant
         :param defect_charge (int):
         :param mpid (str):
+        :initial_defect_structure (str):  Path to the unrelaxed defect structure.
         :param compatibility (DefectCompatibility): Compatibility class instance for
             performing compatibility analysis on defect entry.
 

--- a/doped/pycdt/utils/parse_calculations.py
+++ b/doped/pycdt/utils/parse_calculations.py
@@ -419,7 +419,7 @@ class SingleDefectParser:
         :param dielectric (float or 3x3 matrix): ionic + static contributions to dielectric constant
         :param defect_charge (int):
         :param mpid (str):
-        :initial_defect_structure (str):  Path to the unrelaxed defect structure.
+        :param initial_defect_structure (str):  Path to the unrelaxed defect structure.
         :param compatibility (DefectCompatibility): Compatibility class instance for
             performing compatibility analysis on defect entry.
 

--- a/doped/pycdt/utils/parse_calculations.py
+++ b/doped/pycdt/utils/parse_calculations.py
@@ -480,7 +480,8 @@ class SingleDefectParser:
         except RuntimeError as exc:
             # try transformation.json
             # if auto site-matching failed, try use transformation.json
-            # Bonan: I don't think does anything?
+            # The goal is to find the `defect_site_idx` or `defect_site_idx` based on the tranformation. 
+            # Probably worth refectoring into a function.
             transformation_path = os.path.join(path_to_defect, "transformation.json")
             if not os.path.exists(transformation_path):  # try next folder up
                 orig_transformation_path = transformation_path

--- a/doped/pycdt/utils/vasp.py
+++ b/doped/pycdt/utils/vasp.py
@@ -201,6 +201,13 @@ class DefectRelaxSet(MPRelaxSet):
                     'KPOINTS': kpoints,
                     'POSCAR': self.poscar}
 
+    @property
+    def structure(self):
+        """
+        :return: Structure
+        """
+        return self._structure
+
 
 class DefectStaticSet(MPStaticSet):
     """


### PR DESCRIPTION
This is only a temporary fix by letting `initial_defect_structure` taking precedence, see #17 for more details

The `initial_defect_structure` may be relaxed already causing issues when matching. 
But using `unrelaxed_defect_structure` may result in incorrect results, if it does not have the same ordering as the actual defect structure used in the calculation, since the latter is standardised by `MPRelaxSet`. 