### PR TITLE
Fix a bug detecting the number of formula units

### DIFF
--- a/doped/competing_phases.py
+++ b/doped/competing_phases.py
@@ -518,10 +518,11 @@ class CompetingPhasesAnalyzer:
         temp_data = []
         self.elemental_energies = {}
         for v in self.vaspruns:
+
             rcf = v["reduced_cell_formula"]
-            formulas_per_unit = (
-                list(v["unit_cell_formula"].values())[0] / list(rcf.values())[0]
-            )
+            comp = Composition(v["unit_cell_formula"])
+            formulas_per_unit = comp.get_reduced_composition_and_factor()[1]
+
             final_energy = v["output"]["final_energy"]
             kpoints = "x".join(str(x) for x in v["input"]["kpoints"]["kpoints"][0])
 


### PR DESCRIPTION
Fix #20, as `formulas_per_unit` is used to calculate the energy stored in the CSV output.